### PR TITLE
Add a playground button for creating a blank AOC playground

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,6 +169,41 @@
   (js-await (confetti))
   (+ 1 2 3))
 `.trim();
+
+      const aocDoc = `
+      ;; Helper functions:
+;; (fetch-input year day) - get AOC input
+;; (append str) - append str to DOM
+;; (spy x) - log x to console and return x
+
+;; Remember to update the year and day in the fetch-input call.
+(def input (->> (js-await (fetch-input 2022 1))
+             #_spy
+             str/split-lines
+             (mapv parse-long)))
+
+(defn part-1
+  []
+  (->> input
+    (partition-by nil?)
+    (take-nth 2)
+    (map #(apply + %))
+    (apply max)))
+
+(defn part-2
+  []
+  (->> input
+    (partition-by nil?)
+    (take-nth 2)
+    (map #(apply + %))
+    (sort-by -)
+    (take 3)
+    (apply +)))
+
+(time (part-1))
+#_(time (part-2))`.trim();
+      const aocBoilerplateUrl = 'https://gist.githubusercontent.com/borkdude/cf94b492d948f7f418aa81ba54f428ff/raw/807ed650924d1a75be8b43a4a16dc31b02f4e56c/aoc_ui.cljs';
+
       let boilerplate = urlParams.get('boilerplate');
       let boilerplateSrc;
       if (boilerplate) {
@@ -222,6 +257,15 @@
         url.searchParams.set('src', code);
         window.location = url;
       }
+      window.blankAOC = () => {
+        const code = btoa(aocDoc);
+        const url = new URL(window.location);
+        url.searchParams.set('src', code);
+        url.searchParams.set('boilerplate', aocBoilerplateUrl);
+        url.searchParams.set('repl', true);
+
+        window.location = url;
+      }
 
       window.changeREPL = (target) => {
         document.getElementById('result').innerText = '';
@@ -249,27 +293,37 @@
   <body>
     <div style="display: flex; flex-direction: row; max-height: 90vh; overflow: auto;">
       <div style="position: absolute; right: 0px; top: 0px; margin: 2px">
-      <a href="https://gitHub.com/squint-cljs/squint"><img src="https://img.shields.io/github/stars/squint-cljs/cherry.svg?style=social&label=Star"></a></div>
-      <div id="editor" style="max-height: 90vh; overflow: auto; width: 50%; border: 1px solid grey; border-radius: 10px; margin-bottom: 10px;">
+      <a href="https://gitHub.com/squint-cljs/cherry"><img src="https://img.shields.io/github/stars/squint-cljs/cherry.svg?style=social&label=Star"></a></div>
+      <div id="editor" style="max-height: 90dvh; overflow: auto; width: 50%; border: 1px solid grey; border-radius: 10px; margin-bottom: 10px;">
       </div>
-      <div style="width: 50%; max-height: 90vh; overflow: auto; border: 1px solid grey; border-radius: 10px; margin-left: 10px; padding: 10px; margin-bottom: 10px;">
-              <button onClick="compile()">
-        Compile!
-              </button>
-              <button onClick="share()">
-                Share!
-              </button>
-              <br>
-              <label>REPL-mode
-                <input type="checkbox" id="replCheckBox" name="repl" onChange="changeREPL(this)" />
-              </label>
-              <br>
-              In REPL-mode you can evaluate individual expression by using the ⌘ (macOS) or Windows key + Enter. The result will appear below.
-              <pre><code style="white-space: pre-wrap;max-width:80%;" id="result"></code>
-              </pre>
-              Compiled code:
-              <pre><code style="white-space: pre-wrap;max-width:80%;" id="compiledCode"></code>
-              </pre>
+      <div style="width: 50%;  margin-left: 10px;">
+        <div style="max-height: 90dvh; overflow: auto; border: 1px solid grey; border-radius: 10px; padding: 10px; margin-bottom: 10px;">
+          <div style="display: flex;">
+            <button onClick="compile()">
+              Compile!
+            </button>
+            <button onClick="share()">
+              Share!
+            </button>
+            <span>
+              When sharing, the window URL will be updated to encode the code in the text editor. Copy it and share it with your friends!
+            </span>
+            <br>
+          </div>
+          <label>REPL-mode
+            <input type="checkbox" id="replCheckBox" name="repl" onChange="changeREPL(this)" />
+          </label>
+          <br>
+          In REPL-mode you can evaluate individual expression by using the ⌘ (macOS) or Windows key + Enter. The result will appear below.
+          <pre><code style="white-space: pre-wrap;max-width:80%;" id="result"></code>
+                      </pre>
+          Compiled code:
+          <pre><code style="white-space: pre-wrap;max-width:80%;" id="compiledCode"></code>
+                      </pre>
+        </div>
+        <button style="margin-bottom: 10px;" onClick="blankAOC()">
+          Create blank AOC Playground!
+        </button>
       </div>
     </div>
   </body>

--- a/index.html
+++ b/index.html
@@ -202,7 +202,7 @@
 
 (time (part-1))
 #_(time (part-2))`.trim();
-      const aocBoilerplateUrl = 'https://gist.githubusercontent.com/borkdude/cf94b492d948f7f418aa81ba54f428ff/raw/807ed650924d1a75be8b43a4a16dc31b02f4e56c/aoc_ui.cljs';
+      const aocBoilerplateUrl = 'https://gist.githubusercontent.com/borkdude/cf94b492d948f7f418aa81ba54f428ff/raw/a6e9992b079e20e21d753e8c75a7353c5908b225/aoc_ui.cljs';
 
       let boilerplate = urlParams.get('boilerplate');
       let boilerplateSrc;


### PR DESCRIPTION
To make it clearer and easier to figure out how to create a blank AOC playground. Also added some instructions to the Share function.

https://github.com/squint-cljs/cherry/assets/30010/94563a00-6fbf-4534-a7b4-76d8ce2932bf



- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

(If Slack counts 😄)

- [ ] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/squint-cljs/cherry/blob/master/CHANGELOG.md) file with a description of the addressed issue.
