### PR TITLE
Fix #127 Remove duplicate property in package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 [Cherry](https://github.com/squint-cljs/cherry): Experimental ClojureScript to ES6 module compiler
 
+## 0.1.17 (???)
+
+- [#127](https://github.com/squint-cljs/cherry/issues/127): fix duplicate `cherry-cljs` property in `package.json` which caused issues with some bundlers
+
 ## 0.1.16 (2023-12-07)
 
 - Support `clojure.set`

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "cherry-cljs": ".",
     "esbuild": "^0.14.54",
     "react": "^18.2.0",
-    "shadow-cljs": "^2.20.1",
-    "cherry-cljs": "."
+    "shadow-cljs": "^2.20.1"
   },
   "funding": [
     {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "cherry-cljs",
   "sideEffects": false,
-  "version": "0.1.16",
+  "version": "0.1.17",
   "files": [
     "cljs.core.js",
     "lib",


### PR DESCRIPTION
Duplicate property causes error in bun bundler, but it is also not needed

See: https://github.com/squint-cljs/cherry/issues/127 for more info

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/squint-cljs/cherry/blob/master/CHANGELOG.md) file with a description of the addressed issue.

## Notes:

- I did not add a test, because testing package.json is awkward, but it could be done
- I did not add a date in the [CHANGELOG.md](https://github.com/squint-cljs/cherry/blob/master/CHANGELOG.md), please replace ??? with appropriate date.

<br/>

Thanks everyone who contributes and @borkdude for Cherry and Squint😄