### PR TITLE
Fix :macros support in cherry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 [Cherry](https://github.com/squint-cljs/cherry): Experimental ClojureScript to ES6 module compiler
 
+## Unreleased
+
+- Fix [#159](https://github.com/squint-cljs/cherry/issues/159): Runtime macro resolution for npm package
+
 ## 0.4.30 (2025-07-15)
 
 - Bump squint common compiler code, fixes bugs

--- a/test/cherry/compiler_test.cljs
+++ b/test/cherry/compiler_test.cljs
@@ -5,6 +5,7 @@
    [cherry.embed-test]
    [cherry.html-test]
    [cherry.jsx-test]
+   [cherry.macro-test]
    [cherry.squint-and-cherry-test]
    [cherry.test-utils :refer [js! jss! jsv!]]
    [clojure.string :as str]
@@ -531,4 +532,4 @@ IReset (-reset! [this v]
 
 (defn init []
   (cljs.test/run-tests 'cherry.compiler-test 'cherry.jsx-test 'cherry.squint-and-cherry-test
-                       'cherry.html-test 'cherry.embed-test))
+                       'cherry.html-test 'cherry.embed-test 'cherry.macro-test))

--- a/test/cherry/macro_test.cljs
+++ b/test/cherry/macro_test.cljs
@@ -1,0 +1,66 @@
+(ns cherry.macro-test
+  "Tests for runtime macro expansion via :macros option to compile-string.
+
+  This tests the patch that enables macros to be provided as JavaScript
+  functions and expanded at compile time."
+  (:require
+   [cherry.compiler :as cherry]
+   [clojure.string :as str]
+   [clojure.test :as t :refer [deftest is testing]]))
+
+;; Define macro expansion functions
+;; These are JavaScript functions that return the expanded AST
+(defn my-macro-fn [_form _env x]
+  #js ["str" "\"EXPANDED: \"" x])
+
+(defn foo-macro-fn [_form _env data-ref & operations]
+  #js ["cljs.core/hash-map"
+       ":type" "\"foo-threading\""
+       ":ref" data-ref
+       ":ops" (.concat #js ["cljs.core/vector"] operations)])
+
+(defn my-when-macro-fn [_form _env test & body]
+  #js ["if" test (.concat #js ["do"] body)])
+
+(deftest qualified-macro-test
+  (testing "namespace-qualified macro call"
+    (let [code "(my.ns/my-macro 42)"
+          result (cherry/compile-string code #js {:macros #js {"my.ns" #js {"my-macro" my-macro-fn}}})]
+      (is (str/includes? result "EXPANDED")
+          "Qualified macro call should expand")
+      (is (not (str/includes? result "my_macro"))
+          "Should not contain function call"))))
+
+(deftest unqualified-macro-test
+  (testing "unqualified macro call (auto-refers)"
+    (let [code "(my-macro 99)"
+          result (cherry/compile-string code #js {:macros #js {"my.ns" #js {"my-macro" my-macro-fn}}})]
+      (is (str/includes? result "EXPANDED")
+          "Unqualified macro call should expand")
+      (is (not (str/includes? result "my_macro"))
+          "Should not contain function call"))))
+
+(deftest macro-across-ns-change-test
+  (testing "macro works after (ns ...) form"
+    (let [code "(ns user)\n(my-macro 1)\n(ns other)\n(my-macro 2)"
+          result (cherry/compile-string code #js {:macros #js {"my.ns" #js {"my-macro" my-macro-fn}}})]
+      (is (str/includes? result "EXPANDED")
+          "Macro should work after namespace change"))))
+
+(deftest complex-macro-test
+  (testing "macro with multiple arguments"
+    (let [code "(foo-> :bar (blah 100) (baz 0.5))"
+          result (cherry/compile-string code #js {:macros #js {"my.ns" #js {"foo->" foo-macro-fn}}})]
+      (is (str/includes? result "foo-threading")
+          "Complex macro should expand correctly")
+      (is (str/includes? result ":ref")
+          "Should contain expected keys"))))
+
+(deftest variadic-macro-test
+  (testing "macro that receives variable arguments"
+    (let [code "(my-when (> x 10) (println \"yes\") (println \"ok\"))"
+          result (cherry/compile-string code #js {:macros #js {"my.ns" #js {"my-when" my-when-macro-fn}}})]
+      (is (str/includes? result "if")
+          "my-when macro should expand to if")
+      (is (not (str/includes? result "my_when"))
+          "Should not contain my-when function call"))))


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [X] This PR corresponds to an [issue with a clear problem statement](https://github.com/squint-cljs/cherry/issues/159).

- [X] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [X] I have updated the [CHANGELOG.md](https://github.com/squint-cljs/cherry/blob/master/CHANGELOG.md) file with a description of the addressed issue.

This PR addresses this issue by adding `symbolize-macros-map` (converts string keys to symbols) and `build-macro-refers` (auto-populates `:refers` maps for unqualified calls). Users can now pass macro functions to `compileString` via `:macros` option, supporting both qualified `(my.ns/my-macro x)` and unqualified `(my-macro x)` calls. CLI `:require-macros` still unsupported due to path resolution issues.