### PR TITLE
Add assert macro to built-in-macros

### DIFF
--- a/src/cherry/compiler.cljc
+++ b/src/cherry/compiler.cljc
@@ -105,6 +105,7 @@
                              'js-template defclass/js-template
                              'and squint-macros/core-and
                              'or squint-macros/core-or
+                             'assert squint-macros/core-assert
                              }
                             cc/common-macros))
 

--- a/test/cherry/compiler_test.cljs
+++ b/test/cherry/compiler_test.cljs
@@ -537,6 +537,16 @@ IReset (-reset! [this v]
         body (aget state "body")]
     (is (= 12 (js/eval body)))))
 
+(deftest assert-test
+  (testing "assert with true condition does not throw"
+    (is (= 42 (jsv! "(do (assert true) 42)"))))
+  (testing "assert with false condition throws"
+    (is (thrown-with-msg? js/Error #"Assert failed"
+                          (jsv! "(assert false)"))))
+  (testing "assert with false and message throws with message"
+    (is (thrown-with-msg? js/Error #"custom message"
+                          (jsv! "(assert false \"custom message\")")))))
+
 (defn init []
   (cljs.test/run-tests 'cherry.compiler-test 'cherry.jsx-test 'cherry.squint-and-cherry-test
                        'cherry.html-test 'cherry.embed-test))


### PR DESCRIPTION
Cherry was missing the 'assert entry in built-in-macros, causing (assert ...) to compile as assert.call() without any import, leading to 'assert is not defined' runtime errors.

This adds 'assert squint-macros/core-assert to match Squint's implementation, which properly expands assertions to (when-not x (throw ...)) instead of function calls.

Fixes compilation of assert in ES modules and browsers where no global assert exists.

Please answer the following questions and leave the below in as part of your PR.

- [X] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
https://github.com/squint-cljs/cherry/issues/163

- [x] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/squint-cljs/cherry/blob/master/CHANGELOG.md) file with a description of the addressed issue.
