### PR TITLE
Fix protocol dispatch function IIFE hoisting

### DIFF
--- a/src/cherry/internal/protocols.cljc
+++ b/src/cherry/internal/protocols.cljc
@@ -183,10 +183,11 @@
                                  fname (vary-meta fname assoc
                                          :protocol p
                                          :doc doc)]
-                        `(let [~dyn-name (core/fn
-                                           ~@(map (core/fn [sig]
-                                                    (expand-dyn fname sig))
-                                               sigs))]
+                        `(do
+                           (def ~dyn-name (core/fn
+                                            ~@(map (core/fn [sig]
+                                                     (expand-dyn fname sig))
+                                                sigs)))
                            (defn ~fname
                              ~@(map (core/fn [sig]
                                       (expand-sig fname dyn-name

--- a/test/cherry/compiler_test.cljs
+++ b/test/cherry/compiler_test.cljs
@@ -537,6 +537,16 @@ IReset (-reset! [this v]
         body (aget state "body")]
     (is (= 12 (js/eval body)))))
 
+(deftest protocol-export-test
+  (testing "Protocol dispatch function accessible at module level"
+    (is (= "Alice says hello to Bob"
+           (jsv! "(do (defprotocol Greeter (greet [this name]))
+                      (deftype Person [first-name]
+                        Greeter
+                        (greet [this name]
+                          (str first-name \" says hello to \" name)))
+                      (greet (Person. \"Alice\") \"Bob\"))")))))
+
 (deftest assert-test
   (testing "assert with true condition does not throw"
     (is (= 42 (jsv! "(do (assert true) 42)"))))


### PR DESCRIPTION
Protocol dispatch functions were wrapped in IIFEs during compilation, making them inaccessible at module scope and preventing ES module exports.

Changed defprotocol macro expansion to use a do block that declares both functions at module level, eliminating the IIFE wrapper.

Please answer the following questions and leave the below in as part of your PR.

- [X] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
- #167 

- [X] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/squint-cljs/cherry/blob/master/CHANGELOG.md) file with a description of the addressed issue.
Haven't added yet, to avoid conflicts relative to the other two PRs. Can edit commit to add entry if/when the other ones are handled.
