### PR TITLE
Add satisfies? macro.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix [#163](https://github.com/squint-cljs/cherry/issues/163): Add assert to macros
 - Fix [#165](https://github.com/squint-cljs/cherry/issues/165): Fix ClojureScript protocol dispatch
 - Fix [#169](https://github.com/squint-cljs/cherry/issues/169): `extend-type` on `Object`
+- Fix [#171](https://github.com/squint-cljs/cherry/issues/171): Add `satisfies?` macro
 
 ## 0.4.32 (2025-10-21)
 

--- a/src/cherry/compiler.cljc
+++ b/src/cherry/compiler.cljc
@@ -106,6 +106,7 @@
                              'and squint-macros/core-and
                              'or squint-macros/core-or
                              'assert squint-macros/core-assert
+                             'satisfies? macros/core-satisfies?
                              }
                             cc/common-macros))
 

--- a/src/cherry/internal/macros.cljc
+++ b/src/cherry/internal/macros.cljc
@@ -560,3 +560,11 @@
   [_ _ bindings & body]
   ;; (cljs.analyzer/confirm-bindings &env names)
   `(with-redefs ~bindings ~@body))
+
+(defn core-satisfies?
+  "Returns true if x satisfies protocol"
+  [_ _ protocol x]
+  `(boolean
+    (when-let [proto# (js/Object.getPrototypeOf ~x)]
+      (or (aget proto# ~(str (name protocol) "$"))
+          (aget proto# ~(str "cljs$core$" (name protocol) "$"))))))

--- a/test/cherry/compiler_test.cljs
+++ b/test/cherry/compiler_test.cljs
@@ -553,6 +553,16 @@ IReset (-reset! [this v]
     (is (thrown-with-msg? js/Error #"custom message"
                           (jsv! "(assert false \"custom message\")")))))
 
+(deftest satisfies?-test
+  (testing "satisfies? returns true for implemented custom protocol"
+    (is (true? (jsv! "(defprotocol IFoo (-foo [_])) (deftype Bar [] IFoo (-foo [_] 42)) (satisfies? IFoo (Bar.))"))))
+  (testing "satisfies? returns false for non-implemented custom protocol"
+    (is (false? (jsv! "(defprotocol IFoo (-foo [_])) (deftype Bar []) (satisfies? IFoo (Bar.))"))))
+  (testing "satisfies? returns true for ClojureScript core protocol"
+    (is (true? (jsv! "(deftype T [] ICounted (-count [_] 42)) (satisfies? ICounted (T.))"))))
+  (testing "satisfies? returns false for non-implemented ClojureScript protocol"
+    (is (false? (jsv! "(deftype T []) (satisfies? ICounted (T.))")))))
+
 (deftest protocol-dispatch-test
   (testing "ICounted" (is (= 42 (jsv! "(deftype T [] ICounted (-count [_] 42)) (count (T.))"))))
   (testing "IEmptyableCollection" (is (= 0 (jsv! "(deftype T [] IEmptyableCollection (-empty [_] []) ICounted (-count [_] 0)) (count (empty (T.)))"))))


### PR DESCRIPTION
Note -- I golfed this down to a 4 line impl -- (name protocol) is duplicated. My take without profiling is that this is okay because it only gets called once roughly half the time via the or. Alternately, could either stick it in a let up top (or is that more wasteful re an extra allocation?), or flip the core protocol check to be first in the or. If I remember correctly, satisfies is pretty slow on JVM so shorter is okay here.

- [X] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
#171 

- [X] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [X] I have updated the [CHANGELOG.md](https://github.com/squint-cljs/cherry/blob/master/CHANGELOG.md) file with a description of the addressed issue.
